### PR TITLE
feat: button 컴포넌트 추가

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,8 +20,8 @@ jobs:
         run: npm install -g pnpm
       - name: Install dependencies
         run: pnpm install
-      # - name: Run tests
-      #   run: pnpm test
+      - name: Run tests
+        run: pnpm test
 
   versioning:
     name: Versioning

--- a/src/lib/components/Button/Button.module.scss
+++ b/src/lib/components/Button/Button.module.scss
@@ -1,3 +1,0 @@
-.button_test {
-  background: blue;
-}

--- a/src/lib/components/Button/index.module.scss
+++ b/src/lib/components/Button/index.module.scss
@@ -1,0 +1,70 @@
+$blue: #228be6;
+$gray: #495057;
+$pink: #f06595;
+
+@mixin button-color($color) {
+  background: $color;
+  &:hover {
+    background: lighten($color, 10%);
+  }
+  &:active {
+    background: darken($color, 10%);
+  }
+  &.outlined {
+    color: $color;
+    background: none;
+    border: 1px solid $color;
+  }
+  &.text {
+    color: $color;
+    background: none;
+    border: none;
+  }
+}
+
+.btn {
+  display: inline-flex;
+  color: white;
+  font-weight: bold;
+  outline: none;
+  border-radius: 4px;
+  border: none;
+  cursor: pointer;
+  justify-content: center;
+  align-items: center;
+
+  //color 관리
+  &.blue {
+    @include button-color($blue);
+  }
+
+  &.gray {
+    @include button-color($gray);
+  }
+
+  &.pink {
+    @include button-color($pink);
+  }
+
+  // 사이즈 관리
+  &.lg {
+    height: 3rem;
+    padding-left: 1rem;
+    padding-right: 1rem;
+    font-size: 1.25rem;
+  }
+
+  &.md {
+    height: 2.25rem;
+    padding-left: 1rem;
+    padding-right: 1rem;
+    font-size: 1rem;
+  }
+
+  &.sm {
+    height: 1.75rem;
+    font-size: 0.875rem;
+    padding-left: 1rem;
+    padding-right: 1rem;
+  }
+}

--- a/src/lib/components/Button/index.module.scss
+++ b/src/lib/components/Button/index.module.scss
@@ -1,7 +1,4 @@
-$blue: #228be6;
-$gray: #495057;
-$pink: #f06595;
-
+@use '/src/styles/libs' as *;
 @mixin button-color($color) {
   background: $color;
   &:hover {
@@ -29,21 +26,20 @@ $pink: #f06595;
   outline: none;
   border-radius: 4px;
   border: none;
-  cursor: pointer;
   justify-content: center;
   align-items: center;
 
   //color 관리
   &.blue {
-    @include button-color($blue);
+    @include button-color($BLUE-500);
   }
 
   &.gray {
-    @include button-color($gray);
+    @include button-color($GRAY-500);
   }
 
-  &.pink {
-    @include button-color($pink);
+  &.peach {
+    @include button-color($PEACH-500);
   }
 
   // 사이즈 관리

--- a/src/lib/components/Button/index.stories.ts
+++ b/src/lib/components/Button/index.stories.ts
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react';
 
-import { Button } from '@/lib/components/Button';
+import { Button } from '@/main';
 
 // More on how to set up stories at: https://storybook.js.org/docs/writing-stories#default-export
 const meta = {

--- a/src/lib/components/Button/index.stories.ts
+++ b/src/lib/components/Button/index.stories.ts
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react';
 
-import { Button } from './index';
+import { Button } from '@/lib/components/Button';
 
 // More on how to set up stories at: https://storybook.js.org/docs/writing-stories#default-export
 const meta = {
@@ -18,7 +18,7 @@ const meta = {
       control: { type: 'radio' },
     },
     theme: {
-      options: ['blue', 'gray', 'pink'],
+      options: ['blue', 'gray', 'peach'],
       control: { type: 'radio' },
     },
   },

--- a/src/lib/components/Button/index.stories.ts
+++ b/src/lib/components/Button/index.stories.ts
@@ -1,24 +1,37 @@
 import type { Meta, StoryObj } from '@storybook/react';
 
-import Button from '.';
+import { Button } from './index';
 
 // More on how to set up stories at: https://storybook.js.org/docs/writing-stories#default-export
 const meta = {
   title: 'Example/Button',
   component: Button,
-  parameters: {
-    // Optional parameter to center the component in the Canvas. More info: https://storybook.js.org/docs/configure/story-layout
-    layout: 'centered',
-  },
-  // This component will have an automatically generated Autodocs entry: https://storybook.js.org/docs/writing-docs/autodocs
-  tags: ['autodocs'],
+
   // More on argTypes: https://storybook.js.org/docs/api/argtypes
-  argTypes: {}
+  argTypes: {
+    variant: {
+      options: ['filled', 'outlined', 'text'],
+      control: { type: 'radio' },
+    },
+    size: {
+      options: ['sm', 'md', 'lg'],
+      control: { type: 'radio' },
+    },
+    theme: {
+      options: ['blue', 'gray', 'pink'],
+      control: { type: 'radio' },
+    },
+  },
 } satisfies Meta<typeof Button>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
-  args: {},
+  args: {
+    label: 'Button Test',
+    variant: 'filled',
+    size: 'sm',
+    theme: 'blue',
+  },
 };

--- a/src/lib/components/Button/index.test.tsx
+++ b/src/lib/components/Button/index.test.tsx
@@ -1,0 +1,56 @@
+import { expect, test } from 'vitest';
+import { render } from '@testing-library/react';
+import { Button } from './index';
+
+test('정확한 버튼 label을 렌더한다.', async () => {
+  const buttonText = 'test button text';
+  const button = render(<Button variant="filled" label={buttonText} />);
+
+  expect(button.getByRole('button')).toBeDefined();
+});
+
+test('filled variant에 따른 버튼을 렌더한다.', async () => {
+  const filledButton = render(<Button variant="filled" label="filled Button" />);
+
+  expect(filledButton.getByRole('button').className).toContain('filled');
+});
+
+test('outlined variant에 따른 버튼을 렌더한다.', async () => {
+  const outlinedButton = render(<Button variant="outlined" label="outlined Button" />);
+
+  expect(outlinedButton.getByRole('button').className).toContain('outlined');
+});
+
+test('text variant에 따른 버튼을 렌더한다.', async () => {
+  const textButton = render(<Button variant="text" label="text Button" />);
+
+  expect(textButton.getByRole('button').className).toContain('text');
+});
+
+test('small size 버튼을 렌더한다.', async () => {
+  const buttonText = 'filled button';
+  const button = render(<Button label={buttonText} size="sm" />);
+
+  expect(button.getByRole('button').className).toContain('sm');
+});
+
+test('medium size 버튼을 렌더한다.', async () => {
+  const buttonText = 'filled button';
+  const button = render(<Button label={buttonText} size="md" />);
+
+  expect(button.getByRole('button').className).toContain('md');
+});
+
+test('large size 버튼을 렌더한다.', async () => {
+  const buttonText = 'filled button';
+  const button = render(<Button label={buttonText} size="lg" />);
+
+  expect(button.getByRole('button').className).toContain('lg');
+});
+
+test('정확한 theme에 맞는 버튼을 렌더한다.', async () => {
+  const buttonText = 'filled button';
+  const button = render(<Button label={buttonText} theme="blue" />);
+
+  expect(button.getByRole('button').className).toContain('blue');
+});

--- a/src/lib/components/Button/index.tsx
+++ b/src/lib/components/Button/index.tsx
@@ -1,11 +1,7 @@
-import styles from './Button.module.scss';
+import type { ButtonProps } from './type';
+import classNames from 'classnames';
+import styles from './index.module.scss';
 
-const Button = () => {
-  return (
-    <button type="button" className={styles.button_test}>
-      test버튼
-    </button>
-  );
+export const Button = ({ label, variant = 'filled', size = 'md', theme = 'blue' }: ButtonProps) => {
+  return <button className={classNames(styles.btn, styles[variant], styles[size], styles[theme])}>{label}</button>;
 };
-
-export default Button;

--- a/src/lib/components/Button/index.tsx
+++ b/src/lib/components/Button/index.tsx
@@ -2,6 +2,6 @@ import type { ButtonProps } from './type';
 import classNames from 'classnames';
 import styles from './index.module.scss';
 
-export const Button = ({ label, variant = 'filled', size = 'md', theme = 'blue' }: ButtonProps) => {
+export const Button = ({ label, variant = 'filled', size = 'md', theme = 'GRAY-50' }: ButtonProps) => {
   return <button className={classNames(styles.btn, styles[variant], styles[size], styles[theme])}>{label}</button>;
 };

--- a/src/lib/components/Button/type.ts
+++ b/src/lib/components/Button/type.ts
@@ -1,0 +1,9 @@
+export type ButtonVariant = 'filled' | 'outlined' | 'text';
+export type ButtonSize = 'sm' | 'md' | 'lg';
+
+export interface ButtonProps {
+  label: string;
+  variant?: ButtonVariant;
+  size?: ButtonSize;
+  theme?: string;
+}

--- a/src/lib/index.tsx
+++ b/src/lib/index.tsx
@@ -1,1 +1,1 @@
-export { default as Button } from "./components/Button";
+export * from './components/Button';

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,4 +1,4 @@
 /* eslint-disable react-refresh/only-export-components */
-import "./styles/_global.scss";
+import './styles/_global.scss';
 
-
+export * from './lib';

--- a/src/styles/dayPicker.scss
+++ b/src/styles/dayPicker.scss
@@ -1,7 +1,0 @@
-@use 'libs' as libs;
-
-.rdp-caption {
-  margin-bottom: 5px;
-  padding-bottom: 5px;
-  border-bottom: libs.$BLUISH-GRAY-50 solid 1px;
-}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,9 @@
 {
   "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["src/*"]
+    },
     "target": "ES2020",
     "useDefineForClassFields": true,
     "lib": ["ES2020", "DOM", "DOM.Iterable"],

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,7 +1,6 @@
 import * as path from 'path';
 
 import { defineConfig } from 'vitest/config';
-import react from '@vitejs/plugin-react';
 import dts from 'vite-plugin-dts';
 
 export default defineConfig({
@@ -25,6 +24,11 @@ export default defineConfig({
     },
     commonjsOptions: {
       esmExternals: ['react'],
+    },
+  },
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, './src'),
     },
   },
   plugins: [dts()],


### PR DESCRIPTION
button 컴포넌트를 추가합니다. 
리뷰용으로 스토리북 배포도 하나 더 필요할 것 같긴 하네요..
아 그리고 vite 환경에서 vitest를 사용해보고 싶어서.. (이 [링크](https://www.daleseo.com/vitest/)에서 봤습니다요..) 
vitest로 테스트 환경 세팅 해보았습니다..

변경 내용은
기본적인 button 하나 구현했습니다.
variant, size, theme 정도를 구현했는데 scss로 컴포넌트 만드는것에 대한 이해도가 낮아.. 이런 방식이 맞는지 리뷰해주시면 감사하겠습니다! 
(원래 생각은 size를 number로 받고, theme을 string으로 받아서 좀 더 커스텀 할 수 있게 만들고 싶었는데.. 리액트의 prop을 scss로 어떻게 넘기는지를 잘 모르겠네요..)

<img width="444" alt="image" src="https://github.com/seulgiryuhun/seulgiryuhun-components/assets/59818904/ad174e05-fb4e-426d-ae58-763246a66d4f">
